### PR TITLE
Allow running outside of pull request event context

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
   - [Replacing the entire PR body (continuous)](#replacing-the-entire-pr-body-continuous)
   - [Replacing a specific part of the PR body using a string (one time)](#replacing-a-specific-part-of-the-pr-body-using-a-string-one-time)
   - [Replacing a specific part of the PR body using an HTML Comment Tag (continuous)](#replacing-a-specific-part-of-the-pr-body-using-an-html-comment-tag-continuous)
+  - [Running against different workflow triggers](#running-against-different-workflow-triggers)
 
 ---
 
@@ -83,4 +84,18 @@ will replace what's between the `find` HTML Comment Tags with the `replace` stri
 <!-- AUTOFILLED_PREVIEW_URL -->
 https://example.com/my-preview
 <!-- AUTOFILLED_PREVIEW_URL -->
+```
+
+### Running against different workflow triggers
+
+If running the workflow in response to a `pull_request` event the action will update the associated pull request. 
+
+The action can be configured to update a manually specified pull request instead, by providing the `prNumber`. This way it can be ran in response to a `deployment_status` event, or a manual `workflow_dispatch` trigger.
+
+```yml
+      - name: Replace Pull Request Body
+        uses: ivangabriele/find-and-replace-pull-request-body@v1.1.5
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          prNumber: ${{ inputs.pr }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,8 @@ inputs:
   githubToken:
     description: 'Github Personal Access Token'
     required: true
+  prNumber:
+    description: 'Pull request number (if outside the pull_request context)'
   body:
     description: 'New Pull Request body'
   find:

--- a/index.dist.js
+++ b/index.dist.js
@@ -87728,17 +87728,15 @@ async function run() {
 
     if (!context.payload.pull_request && !prNumber) {
       throw new Error(
-        // must provide one
-      //   "You can't use `body` input while setting `find` and `replace` ones.\n" +
-      //     'Please check your setup: https://github.com/ivangabriele/find-and-replace-pull-request-body#usage',
+        'You must either trigger this action from a pull request, or manually set the `prNumber` input\n' +
+          'Please check your setup: https://github.com/ivangabriele/find-and-replace-pull-request-body#usage',
       )
     }
 
     if (context.payload.pull_request && prNumber) {
       throw new Error(
-        // only one
-      //   "You can't use `body` input while setting `find` and `replace` ones.\n" +
-      //     'Please check your setup: https://github.com/ivangabriele/find-and-replace-pull-request-body#usage',
+        "You can't use `prNumber` while in the context of a pull request event.\n" +
+          'Please check your setup: https://github.com/ivangabriele/find-and-replace-pull-request-body#usage',
       )
     }
 
@@ -87749,7 +87747,7 @@ async function run() {
       pullRequestNumber = context.payload.pull_request.number;
       pullRequestBody = context.payload.pull_request.body;
     } else {
-      const {data: pullRequest} = await octokit.rest.pulls.get({
+      const { data: pullRequest } = await octokit.rest.pulls.get({
         ...context.repo,
         pull_number: parseInt(prNumber, 10),
       });

--- a/index.dist.js
+++ b/index.dist.js
@@ -87689,6 +87689,7 @@ github.getOctokit = getOctokit;
 async function run() {
   try {
     const githubToken = core.getInput('githubToken', { required: true });
+    const prNumber = core.getInput('prNumber');
     const body = core.getInput('body');
     const find = core.getInput('find');
     const isHtmlCommentTag = core.getInput('isHtmlCommentTag').toLowerCase() === 'true';
@@ -87725,8 +87726,37 @@ async function run() {
     const { context } = github;
     const octokit = github.getOctokit(githubToken);
 
-    const pullRequestNumber = context.payload.pull_request.number;
-    const pullRequestBody = context.payload.pull_request.body;
+    if (!context.payload.pull_request && !prNumber) {
+      throw new Error(
+        // must provide one
+      //   "You can't use `body` input while setting `find` and `replace` ones.\n" +
+      //     'Please check your setup: https://github.com/ivangabriele/find-and-replace-pull-request-body#usage',
+      )
+    }
+
+    if (context.payload.pull_request && prNumber) {
+      throw new Error(
+        // only one
+      //   "You can't use `body` input while setting `find` and `replace` ones.\n" +
+      //     'Please check your setup: https://github.com/ivangabriele/find-and-replace-pull-request-body#usage',
+      )
+    }
+
+    let pullRequestNumber;
+    let pullRequestBody;
+
+    if (context.payload.pull_request) {
+      pullRequestNumber = context.payload.pull_request.number;
+      pullRequestBody = context.payload.pull_request.body;
+    } else {
+      const {data: pullRequest} = await octokit.rest.pulls.get({
+        ...context.repo,
+        pull_number: parseInt(prNumber, 10),
+      });
+
+      pullRequestNumber = pullRequest.number;
+      pullRequestBody = pullRequest.body;
+    }
 
     if (!body.length && !pullRequestBody) {
       throw new Error(

--- a/index.js
+++ b/index.js
@@ -43,28 +43,26 @@ export async function run() {
 
     if (!context.payload.pull_request && !prNumber) {
       throw new Error(
-        // must provide one
-      //   "You can't use `body` input while setting `find` and `replace` ones.\n" +
-      //     'Please check your setup: https://github.com/ivangabriele/find-and-replace-pull-request-body#usage',
+        'You must either trigger this action from a pull request, or manually set the `prNumber` input\n' +
+          'Please check your setup: https://github.com/ivangabriele/find-and-replace-pull-request-body#usage',
       )
     }
 
     if (context.payload.pull_request && prNumber) {
       throw new Error(
-        // only one
-      //   "You can't use `body` input while setting `find` and `replace` ones.\n" +
-      //     'Please check your setup: https://github.com/ivangabriele/find-and-replace-pull-request-body#usage',
+        "You can't use `prNumber` while in the context of a pull request event.\n" +
+          'Please check your setup: https://github.com/ivangabriele/find-and-replace-pull-request-body#usage',
       )
     }
 
-    let pullRequestNumber;
-    let pullRequestBody;
+    let pullRequestNumber
+    let pullRequestBody
 
     if (context.payload.pull_request) {
       pullRequestNumber = context.payload.pull_request.number
       pullRequestBody = context.payload.pull_request.body
     } else {
-      const {data: pullRequest} = await octokit.rest.pulls.get({
+      const { data: pullRequest } = await octokit.rest.pulls.get({
         ...context.repo,
         pull_number: parseInt(prNumber, 10),
       })


### PR DESCRIPTION
I'd like to be able to run this action on the `deployment_status` event instead of on updates to a pull request to avoid constructing URLs from the PR number. When running it against `deployment_status` there is no `context.payload.pull_request` object, resulting in the following error. 
```
Run ivangabriele/find-and-replace-pull-request-body@v1.1.5
Error: Cannot read properties of undefined (reading 'number')
```

In our own actions code we have some scripts to look up the PR based on the ref, so ideally we'd have something along the lines of this PR to enable explicitly passing a PR number. 

I'm happy to change this implementation as you see fit (and add tests). Or if you'd prefer not to bring this functionality into yours we could fork and rename it, or bring a minimal version of the code into our codebase